### PR TITLE
bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["go-plugin", "golang", "hashicorp", "grpc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = "0.6"
-tonic-health = "0.5"
+tonic = "0.9.2"
+tonic-health = "0.9.2"
 portpicker = "0.1"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "fs"] }
 log = "0.4"
@@ -24,8 +24,8 @@ http-body = "0.4"
 bytes = "1.1.0"
 pin-project = "1.0"
 futures = "0.3.19"
-prost = "0.9"
-prost-types = "0.9"
+prost = "0.11.9"
+prost-types = "0.11.9"
 async-stream = "0.3.2"
 triggered = "0.1.2"
 gag = "1.0"
@@ -41,4 +41,4 @@ hyperlocal = "0.8"
 assert_matches = "1.5.0"
 
 [build-dependencies]
-tonic-build = "0.6"
+tonic-build = "0.9.2"

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_client(false)
-        .format(true)
         .compile(
             &[
                 "proto/grpc_broker.proto",

--- a/src/grpc_broker.rs
+++ b/src/grpc_broker.rs
@@ -12,6 +12,7 @@ use futures::stream::StreamExt;
 use hyper::{Body, Request, Response};
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UnixStream;
@@ -87,7 +88,7 @@ impl GRpcBroker {
 
     pub async fn new_grpc_server<S>(&mut self, plugin: S) -> Result<ServiceId, Error>
     where
-        S: Service<Request<Body>, Response = Response<BoxBody>>
+        S: Service<Request<Body>, Response = Response<BoxBody>, Error=Infallible>
             + NamedService
             + Clone
             + Send
@@ -112,7 +113,7 @@ impl GRpcBroker {
         plugin: S,
     ) -> Result<ServiceId, Error>
     where
-        S: Service<Request<Body>, Response = Response<BoxBody>>
+        S: Service<Request<Body>, Response = Response<BoxBody>, Error=Infallible>
             + NamedService
             + Clone
             + Send

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use anyhow::{anyhow, Context, Result};
 use http::{Request, Response};
 use hyper::Body;
 use std::clone::Clone;
+use std::convert::Infallible;
 use std::env;
 use std::marker::Send;
 use tonic::body::BoxBody;
@@ -165,7 +166,7 @@ impl Server {
 
     pub async fn serve<S>(&mut self, plugin: S) -> Result<(), Error>
     where
-        S: Service<Request<Body>, Response = Response<BoxBody>>
+        S: Service<Request<Body>, Response = Response<BoxBody>, Error=Infallible>
             + NamedService
             + Clone
             + Send


### PR DESCRIPTION
tonic 0.6 had a bug that generated code from my proto files which wouldn't compile. this was fixed in newer versions of tonic, but using those made my project incompatible with this one, so i had to update it